### PR TITLE
Fix a markdown typo

### DIFF
--- a/runtime/manual/basics/permissions.md
+++ b/runtime/manual/basics/permissions.md
@@ -276,7 +276,7 @@ deno run --deny-write=foo.txt,bar.txt script.ts
 ```
 
 _Any paths specified with `--deny-write[=<PATH>...]` will be denied access, even
-if they are specified in `--allow-write`.
+if they are specified in `--allow-write`._
 
 ### Certification errors
 


### PR DESCRIPTION
https://docs.deno.com/runtime/manual/basics/permissions/#file-system-write-access

<img width="876" alt="image" src="https://github.com/user-attachments/assets/6f5f089d-82e3-4f9a-bf46-0de98c5f8736">